### PR TITLE
Created separate public function

### DIFF
--- a/JSSAlertView/Classes/JSSAlertView.swift
+++ b/JSSAlertView/Classes/JSSAlertView.swift
@@ -405,7 +405,7 @@ open class JSSAlertView: UIViewController {
 	/// - Parameters:
 	///   - withCallback: callback availabel
 	///   - source: Type of removing view see ActionType
-	public func closeView(_ withCallback: Bool, source: ActionType = .close) {
+	func closeView(_ withCallback: Bool, source: ActionType = .close) {
 		UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 0.5, options: [], animations: {
 			self.containerView.center.y = self.view.center.y + self.viewHeight!
 			}, completion: { finished in
@@ -426,6 +426,11 @@ open class JSSAlertView: UIViewController {
 				})
 		})
 	}
+  
+  // Public API to dismiss alert
+  public func closeView(_ withCallback: Bool) {
+    closeView(withCallback, source: .close)
+  }
 
     
 	/// Removes view from superview


### PR DESCRIPTION
Can’t use closeView(_ withCallback: Bool, source: ActionType = .close)
method as public because ActionType is internal