### PR TITLE
Rename removeFromParent to removeFromParentViewController

### DIFF
--- a/JSSAlertView/Classes/JSSAlertView.swift
+++ b/JSSAlertView/Classes/JSSAlertView.swift
@@ -432,7 +432,7 @@ open class JSSAlertView: UIViewController {
 	/// Removes view from superview
 	func removeView() {
 		isAlertOpen = false
-		removeFromParent()
+		removeFromParentViewController()
 		view.removeFromSuperview()
 	}
 


### PR DESCRIPTION
Addressed issue #80.

Modified JSSAlertView#removeView method that was calling
the deprecated UIViewController#removeFromParent. This
change is necessary to allow JSSAlertView to work with the
lastest version of Swift.